### PR TITLE
refactor: simplify gradient calculation

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -106,6 +106,7 @@ impl VibrantApplication {
             .application_icon("io.github.fkinoshita.Vibrant")
             .developer_name("Felipe Kinoshita")
             .comments(gettext("Generate CSS gradients"))
+            .license_type(gtk::License::Gpl30)
             .version(VERSION)
             .developers(vec!["Felipe Kinoshita"])
             .copyright("© 2023 Felipe Kinoshita")

--- a/src/application.rs
+++ b/src/application.rs
@@ -18,6 +18,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
+use gettextrs::gettext;
 use gtk::prelude::*;
 use gtk::{gio, glib};
 
@@ -104,7 +105,7 @@ impl VibrantApplication {
             .application_name("Vibrant")
             .application_icon("io.github.fkinoshita.Vibrant")
             .developer_name("Felipe Kinoshita")
-            .comments("Generate CSS gradients")
+            .comments(gettext("Generate CSS gradients"))
             .version(VERSION)
             .developers(vec!["Felipe Kinoshita"])
             .copyright("© 2023 Felipe Kinoshita")

--- a/src/window.rs
+++ b/src/window.rs
@@ -28,34 +28,6 @@ use adw::subclass::prelude::*;
 
 use crate::config::PROFILE;
 
-pub enum Direction {
-    Left,
-    Right,
-    Top,
-    Bottom,
-}
-
-impl Direction {
-    fn from_u32(value: u32) -> Direction {
-        match value {
-            0 => Direction::Left,
-            1 => Direction::Right,
-            2 => Direction::Top,
-            3 => Direction::Bottom,
-            _ => panic!("Unknown value: {}", value),
-        }
-    }
-
-    fn degree(&self) -> u16 {
-        match self {
-            Direction::Left => 270,
-            Direction::Right => 90,
-            Direction::Top => 180,
-            Direction::Bottom => 0,
-        }
-    }
-}
-
 mod imp {
     use super::*;
 
@@ -130,6 +102,11 @@ impl VibrantWindow {
 
         imp.color_one_entry.set_text("blue");
         imp.color_two_entry.set_text("pink");
+        self.set_gradient_css(
+            (self.imp().direction_combo.selected() * 90) as u16,
+            "blue",
+            "pink",
+        );
     }
 
     fn setup_signals(&self) {
@@ -138,12 +115,11 @@ impl VibrantWindow {
         imp.direction_combo.connect_notify_local(
             Some("selected"),
             clone!(@strong self as this => move |combo, _| {
-                let selected_direction = Direction::from_u32(combo.selected());
 
                 let color1 = this.imp().color_one_entry.text();
                 let color2 = this.imp().color_two_entry.text();
 
-                this.set_gradient_css(selected_direction.degree(), &color1, &color2);
+                this.set_gradient_css((dbg!(dbg!(combo.selected()) * 90)) as u16, &color1, &color2);
             }),
         );
 
@@ -152,9 +128,8 @@ impl VibrantWindow {
             clone!(@strong self as this => move |entry, _| {
                 let color1 = entry.text();
                 let color2 = this.imp().color_two_entry.text();
-                let direction = Direction::from_u32(this.imp().direction_combo.selected());
 
-                this.set_gradient_css(direction.degree(), &color1, &color2);
+                this.set_gradient_css((this.imp().direction_combo.selected() * 90) as u16, &color1, &color2);
             }),
         );
 
@@ -164,9 +139,8 @@ impl VibrantWindow {
                 let color1 = this.imp().color_one_entry.text();
                 let color2 = entry.text();
 
-                let direction = Direction::from_u32(this.imp().direction_combo.selected());
 
-                this.set_gradient_css(direction.degree(), &color1, &color2);
+                this.set_gradient_css((this.imp().direction_combo.selected() * 90) as u16, &color1, &color2);
             }),
         );
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -102,11 +102,7 @@ impl VibrantWindow {
 
         imp.color_one_entry.set_text("blue");
         imp.color_two_entry.set_text("pink");
-        self.set_gradient_css(
-            (self.imp().direction_combo.selected() * 90) as u16,
-            "blue",
-            "pink",
-        );
+        self.update_gradient();
     }
 
     fn setup_signals(&self) {
@@ -114,43 +110,35 @@ impl VibrantWindow {
 
         imp.direction_combo.connect_notify_local(
             Some("selected"),
-            clone!(@strong self as this => move |combo, _| {
-
-                let color1 = this.imp().color_one_entry.text();
-                let color2 = this.imp().color_two_entry.text();
-
-                this.set_gradient_css((dbg!(dbg!(combo.selected()) * 90)) as u16, &color1, &color2);
+            clone!(@strong self as this => move |_combo, _| {
+                this.update_gradient();
             }),
         );
 
         imp.color_one_entry.connect_notify_local(
             Some("text"),
-            clone!(@strong self as this => move |entry, _| {
-                let color1 = entry.text();
-                let color2 = this.imp().color_two_entry.text();
-
-                this.set_gradient_css((this.imp().direction_combo.selected() * 90) as u16, &color1, &color2);
+            clone!(@strong self as this => move |_entry, _| {
+                this.update_gradient();
             }),
         );
 
         imp.color_two_entry.connect_notify_local(
             Some("text"),
-            clone!(@strong self as this => move |entry, _| {
-                let color1 = this.imp().color_one_entry.text();
-                let color2 = entry.text();
-
-
-                this.set_gradient_css((this.imp().direction_combo.selected() * 90) as u16, &color1, &color2);
+            clone!(@strong self as this => move |_entry, _| {
+                this.update_gradient();
             }),
         );
     }
 
-    fn set_gradient_css(&self, degrees: u16, color1: &str, color2: &str) {
+    fn update_gradient(&self) {
+        let imp = self.imp();
         let provider = gtk::CssProvider::new();
 
         let css = format!(
             ".gradient-box {{background: linear-gradient({}deg, {}, {});}}",
-            degrees, color1, color2
+            imp.direction_combo.selected() as u16 * 90,
+            imp.color_one_entry.text(),
+            imp.color_two_entry.text()
         );
 
         provider.load_from_data(css.as_str());

--- a/src/window.ui
+++ b/src/window.ui
@@ -87,10 +87,10 @@
                                 <property name="model">
                                   <object class="GtkStringList">
                                     <items>
-                                      <item translatable="yes">To Left</item>
-                                      <item translatable="yes">To Right</item>
-                                      <item translatable="yes">To Top</item>
-                                      <item translatable="yes">To Bottom</item>
+                                      <item translatable="yes">Bottom</item>
+                                      <item translatable="yes">Right</item>
+                                      <item translatable="yes">Top</item>
+                                      <item translatable="yes">Left</item>
                                     </items>
                                   </object>
                                 </property>


### PR DESCRIPTION
I decided to remove some of the duplicated degree calculation code and move it to an associated function in 78ba20dd35d044fb70b56fe16eef935e52046848. 
This led me to realize that by slightly changing the order of the ComboRow, the `match` is unnecessary, and instead the degree can be calculated directly from the selected value (918b639fbf92b13af56f1794ee16018cde3fcb8d).
Finally, since all the callbacks do essentially the same work of updating the gradient, I moved them to the same function.

This also makes the AboutWindow comment translatable and adds the license to it.

If you disagree with any of these changes, feel free to either add a review comment or drop them when merging.