### PR TITLE
feat: select gradient type

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -131,7 +131,7 @@ impl VibrantWindow {
         imp.gradient_combo.connect_selected_item_notify(
             clone!(@strong self as this => move |combo| {
                 //disable when gradient is radial, as it does effect anything
-                this.imp().direction_combo.set_activatable(combo.selected() != 1);
+                this.imp().direction_combo.set_sensitive(combo.selected() != 1);
                 this.update_gradient();
             }),
         );

--- a/src/window.rs
+++ b/src/window.rs
@@ -166,7 +166,11 @@ impl VibrantWindow {
         let gradient = match gradient_type {
             GradientType::Linear => format!("linear-gradient({}deg,", degree),
             GradientType::Radial => "radial-gradient(".to_owned(),
-            GradientType::Conic => format!("conic-gradient(from {}deg,", degree),
+            GradientType::Conic => format!(
+                "conic-gradient(from {}deg,",
+                //adjust degree to only switch bottom and top direction
+                degree + (degree % 180 == 0) as u16 * 180
+            ),
         };
 
         let css = format!(

--- a/src/window.rs
+++ b/src/window.rs
@@ -129,7 +129,9 @@ impl VibrantWindow {
         let imp = self.imp();
 
         imp.gradient_combo.connect_selected_item_notify(
-            clone!(@strong self as this => move |_combo| {
+            clone!(@strong self as this => move |combo| {
+                //disable when gradient is radial, as it does effect anything
+                this.imp().direction_combo.set_activatable(combo.selected() != 1);
                 this.update_gradient();
             }),
         );

--- a/src/window.ui
+++ b/src/window.ui
@@ -81,6 +81,24 @@
                             <property name="title" translatable="yes">Properties</property>
 
                             <child>
+                              <object class="AdwComboRow" id="gradient_combo">
+                                <property name="title" translatable="yes">Gradient type</property>
+
+                                <property name="model">
+                                  <object class="GtkStringList">
+                                    <items>
+                                      <item translatable="yes">Linear</item>
+                                      <item translatable="yes">Radient</item>
+                                      <item translatable="yes">Conic</item>
+                                    </items>
+                                  </object>
+                                </property>
+
+                              </object>
+                            </child>
+
+
+                            <child>
                               <object class="AdwComboRow" id="direction_combo">
                                 <property name="title" translatable="yes">Direction</property>
 


### PR DESCRIPTION
Allows the user to select between the various gradient types.

If the `radial` gradient is select, the direction combo row is disabled, as its settings do not change the gradient.
![Gradient selection](https://github.com/fkinoshita/Vibrant/assets/63370021/3b45250b-cdd6-421d-a16a-9a937a49bbb7)
![Conic gradient](https://github.com/fkinoshita/Vibrant/assets/63370021/7c620a8e-ffc6-499f-9978-62614f42b82b)
