### PR TITLE
feat: use color buttons

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 gettext-rs = { version = "0.7", features = ["gettext-system"] }
-gtk = { version = "0.6", package = "gtk4" }
+gtk = { version = "0.6", package = "gtk4", features = ["gnome_44"] }
 
 [dependencies.adw]
 package = "libadwaita"

--- a/src/window.rs
+++ b/src/window.rs
@@ -20,7 +20,7 @@
 
 use glib::clone;
 
-use gtk::prelude::*;
+use gtk::{gdk, prelude::*};
 use gtk::{gio, glib};
 
 use adw::prelude::*;
@@ -49,9 +49,9 @@ mod imp {
         pub direction_combo: TemplateChild<adw::ComboRow>,
 
         #[template_child]
-        pub color_one_entry: TemplateChild<adw::EntryRow>,
+        pub color_one_button: TemplateChild<gtk::ColorDialogButton>,
         #[template_child]
-        pub color_two_entry: TemplateChild<adw::EntryRow>,
+        pub color_two_button: TemplateChild<gtk::ColorDialogButton>,
     }
 
     #[glib::object_subclass]
@@ -100,8 +100,8 @@ impl VibrantWindow {
             self.add_css_class("devel");
         }
 
-        imp.color_one_entry.set_text("blue");
-        imp.color_two_entry.set_text("pink");
+        imp.color_one_button.set_rgba(&gdk::RGBA::BLUE);
+        imp.color_two_button.set_rgba(&gdk::RGBA::WHITE);
         self.update_gradient();
     }
 
@@ -115,19 +115,15 @@ impl VibrantWindow {
             }),
         );
 
-        imp.color_one_entry.connect_notify_local(
-            Some("text"),
-            clone!(@strong self as this => move |_entry, _| {
+        imp.color_one_button
+            .connect_rgba_notify(clone!(@strong self as this => move |_| {
                 this.update_gradient();
-            }),
-        );
+            }));
 
-        imp.color_two_entry.connect_notify_local(
-            Some("text"),
-            clone!(@strong self as this => move |_entry, _| {
+        imp.color_two_button
+            .connect_rgba_notify(clone!(@strong self as this => move |_| {
                 this.update_gradient();
-            }),
-        );
+            }));
     }
 
     fn update_gradient(&self) {

--- a/src/window.rs
+++ b/src/window.rs
@@ -137,15 +137,15 @@ impl VibrantWindow {
         let css = format!(
             ".gradient-box {{background: linear-gradient({}deg, {}, {});}}",
             imp.direction_combo.selected() as u16 * 90,
-            imp.color_one_entry.text(),
-            imp.color_two_entry.text()
+            imp.color_one_button.rgba(),
+            imp.color_two_button.rgba()
         );
 
         provider.load_from_data(css.as_str());
 
-        self.imp()
-            .gradient_box
-            .style_context()
-            .add_provider(&provider, 1000);
+        if let Some(display) = gtk::gdk::Display::default() {
+            #[allow(deprecated)] //https://github.com/gtk-rs/gtk4-rs/issues/1317
+            gtk::StyleContext::add_provider_for_display(&display, &provider, 1000);
+        }
     }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -140,8 +140,7 @@ impl VibrantWindow {
         provider.load_from_data(css.as_str());
 
         if let Some(display) = gtk::gdk::Display::default() {
-            #[allow(deprecated)] //https://github.com/gtk-rs/gtk4-rs/issues/1317
-            gtk::StyleContext::add_provider_for_display(&display, &provider, 1000);
+            gtk::style_context_add_provider_for_display(&display, &provider, 1000);
         }
     }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -101,7 +101,8 @@ impl VibrantWindow {
         }
 
         imp.color_one_button.set_rgba(&gdk::RGBA::BLUE);
-        imp.color_two_button.set_rgba(&gdk::RGBA::WHITE);
+        imp.color_two_button
+            .set_rgba(&gdk::RGBA::new(1.0, 0.75, 0.8, 1.0));
         self.update_gradient();
     }
 

--- a/src/window.ui
+++ b/src/window.ui
@@ -104,16 +104,31 @@
                         <child>
                           <object class="AdwPreferencesGroup">
                             <property name="title" translatable="yes">Colors</property>
-
                             <child>
-                              <object class="AdwEntryRow" id="color_one_entry">
+                              <object class="AdwActionRow">
                                 <property name="title" translatable="yes" context="Color in a list">Color 1</property>
+                                <property name="activatable-widget">color_one_button</property>
+                                <child type="suffix">
+                                  <object class="GtkColorDialog" id="color_one_dialog"></object>
+                                  <object class="GtkColorDialogButton" id="color_one_button">
+                                    <property name="valign">center</property>
+                                    <property name="dialog">color_one_dialog</property>
+                                  </object>
+                                </child>
                               </object>
                             </child>
 
                             <child>
-                              <object class="AdwEntryRow" id="color_two_entry">
+                              <object class="AdwActionRow">
                                 <property name="title" translatable="yes" context="Color in a list">Color 2</property>
+                                <property name="activatable-widget">color_two_button</property>
+                                <child type="suffix">
+                                  <object class="GtkColorDialog" id="color_two_dialog"></object>
+                                  <object class="GtkColorDialogButton" id="color_two_button">
+                                    <property name="valign">center</property>
+                                    <property name="dialog">color_two_dialog</property>
+                                  </object>
+                                </child>
                               </object>
                             </child>
 


### PR DESCRIPTION
Switches the color entry to [`GtkColorDialogButton`](https://docs.gtk.org/gtk4/class.ColorDialogButton.html). This brings it more inline with other GNOME apps and allows more a greater choice of colors via the `GtkColorDialog`.
![Vibrant with color buttons](https://github.com/fkinoshita/Vibrant/assets/63370021/3044af86-9822-42e9-8a03-983f20fb1557)
