### PR TITLE
fix: use min size for gradient box

### DIFF
--- a/src/window.ui
+++ b/src/window.ui
@@ -62,6 +62,7 @@
 
                             <property name="child">
                               <object class="GtkBox" id="gradient_box">
+                                <property name="height-request">120</property>
                                 <property name="hexpand">true</property>
                                 <property name="vexpand">true</property>
 


### PR DESCRIPTION
Previously it was possible to hide the gradient by reducing the window size. This pr adds a minimum size for the gradient box, so it is no longer possible to hide it by simply resizing it. 

| Before                                                                                                               	| After                                                                                                                 	|
|----------------------------------------------------------------------------------------------------------------------	|-----------------------------------------------------------------------------------------------------------------------	|
| ![Gradientbox is hidden](https://github.com/fkinoshita/Vibrant/assets/63370021/3d003d3d-3f96-47ae-bdb9-d1ba77513243) 	| ![Gradientbox is visible](https://github.com/fkinoshita/Vibrant/assets/63370021/4993b3c5-0fd3-4659-8b7b-cae55a9aaec6) 	|