### PR TITLE
feat: copy CSS

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -158,9 +158,8 @@ impl VibrantWindow {
         );
     }
 
-    fn update_gradient(&self) {
+    fn generate_css(&self) -> String {
         let imp = self.imp();
-        let provider = gtk::CssProvider::new();
 
         let gradient_type = GradientType::from(imp.gradient_combo.selected());
         let degree = imp.direction_combo.selected() as u16 * 90;
@@ -175,14 +174,17 @@ impl VibrantWindow {
             ),
         };
 
-        let css = format!(
+        format!(
             ".gradient-box {{background: {} {}, {});}}",
             gradient,
             imp.color_one_entry.text(),
             imp.color_two_entry.text()
-        );
+        )
+    }
 
-        provider.load_from_data(css.as_str());
+    fn update_gradient(&self) {
+        let provider = gtk::CssProvider::new();
+        provider.load_from_data(&self.generate_css());
 
         self.imp()
             .gradient_box

--- a/src/window.rs
+++ b/src/window.rs
@@ -18,6 +18,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
+use gettextrs::gettext;
 use glib::clone;
 
 use gtk::prelude::*;
@@ -82,6 +83,7 @@ mod imp {
 
         fn class_init(klass: &mut Self::Class) {
             klass.bind_template();
+            Self::Type::bind_template_callbacks(klass);
         }
 
         fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
@@ -101,6 +103,7 @@ glib::wrapper! {
         @extends gtk::Widget, gtk::Window, gtk::ApplicationWindow, adw::ApplicationWindow,        @implements gio::ActionGroup, gio::ActionMap;
 }
 
+#[gtk::template_callbacks]
 impl VibrantWindow {
     pub fn new<P: glib::IsA<gtk::Application>>(application: &P) -> Self {
         let win: VibrantWindow = glib::Object::builder()
@@ -156,6 +159,16 @@ impl VibrantWindow {
                 this.update_gradient();
             }),
         );
+    }
+
+    #[template_callback]
+    pub fn copy_css(&self, _button: gtk::Button) {
+        let clipboard = self.clipboard();
+        clipboard.set_text(&self.generate_css());
+
+        self.imp()
+            .toast_overlay
+            .add_toast(adw::Toast::new(&gettext("Copied CSS to clipboard")))
     }
 
     fn generate_css(&self) -> String {

--- a/src/window.ui
+++ b/src/window.ui
@@ -27,9 +27,11 @@
                             <child>
                               <object class="AdwButtonContent">
                                 <property name="label" translatable="yes">Generate CSS</property>
-                                <property name="icon-name">arrow-into-box-symbolic</property>
+                                <property name="icon-name">edit-copy-symbolic</property>
                               </object>
                             </child>
+
+                            <signal name="clicked" handler="copy_css" swapped="true" />
 
                           </object>
                         </child>


### PR DESCRIPTION
Copy the generated CSS when clicking the `Generate CSS` button in the header bar. After copying, it will display a toast to let the user know, the CSS has been copied to the clipboard.

![Generated CSS toast](https://github.com/fkinoshita/Vibrant/assets/63370021/16189209-6591-40aa-9eca-72429a098085)
